### PR TITLE
bugfix: Make default shaders work on more browsers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Autodetect text files
+* text=auto

--- a/public/shaders/default/shader.frag.glsl
+++ b/public/shaders/default/shader.frag.glsl
@@ -1,5 +1,5 @@
 #version 100
-precision mediump float;
+precision highp float;
 
 uniform float time;
 uniform vec2 res;


### PR DESCRIPTION
precision needs to match for shared uniforms on some browsers, originally tested with chrome which didn't care /shrug